### PR TITLE
Add a Settings screen with lock, progress-bar and speed-time options

### DIFF
--- a/audiobook_app/ui.c
+++ b/audiobook_app/ui.c
@@ -1587,6 +1587,20 @@ static int handle_settings_touch(ui_state_t *ui, int x, int y) {
     return 1;
 }
 
+
+/* Wall-clock conversion for the "Times follow speed" setting.
+ *
+ * Book positions are stored in book time. At 1.5x an hour of book takes forty
+ * minutes to hear, so a listener asking "how much is left" wants the forty, not
+ * the sixty. Dividing by the speed converts book time to real time; with the
+ * setting off, callers use the raw value and nothing changes. */
+static int64_t speed_scaled_ms(const ui_state_t *ui, int64_t ms) {
+    if (!ui->settings_val[SETTING_SPEED_ADJUSTS_TIME]) return ms;
+    int permille = player_get_speed();
+    if (permille <= 0) return ms;
+    return ms * 1000 / permille;
+}
+
 /* ---- Screen drawing: List ---------------------------------------------- */
 
 /* list_item_t is defined in ui.h (shared with the render cache). */
@@ -2544,9 +2558,12 @@ static void draw_now_playing(ui_state_t *ui) {
         total_ms = ui->scrub_total_ms;
     }
 
-    render_text(r, 16, y, "Position:", FONT_SCALE_1, COL_GRAY_LT);
+    render_text(r, 16, y,
+                ui->settings_val[SETTING_SPEED_ADJUSTS_TIME] ? "Listened:"
+                                                             : "Position:",
+                FONT_SCALE_1, COL_GRAY_LT);
     y += 30;
-    render_time(r, 16, y, pos_ms, FONT_SCALE_3, COL_WHITE);
+    render_time(r, 16, y, speed_scaled_ms(ui, pos_ms), FONT_SCALE_3, COL_WHITE);
     y += 70;
 
     /* Progress bar with a draggable handle at the current position. Pressing
@@ -2569,13 +2586,24 @@ static void draw_now_playing(ui_state_t *ui) {
         y += 18;
 
         /* Time labels */
-        render_time(r, 16, y, pos_ms, FONT_SCALE_1, COL_GRAY_LT);
+        render_time(r, 16, y, speed_scaled_ms(ui, pos_ms), FONT_SCALE_1,
+                    COL_GRAY_LT);
         {
             char dur_buf[32];
-            int tsec = (int)(total_ms / 1000);
+            /* With the setting on the right-hand figure becomes time left at
+             * the current speed, which is the number a listener is actually
+             * asking for; with it off it stays the book's total duration. */
+            int64_t right_ms = total_ms;
+            const char *pfx = "";
+            if (ui->settings_val[SETTING_SPEED_ADJUSTS_TIME]) {
+                right_ms = speed_scaled_ms(ui, total_ms - pos_ms);
+                if (right_ms < 0) right_ms = 0;
+                pfx = "-";
+            }
+            int tsec = (int)(right_ms / 1000);
             int th = tsec / 3600, tm = (tsec % 3600) / 60;
-            if (th > 0) snprintf(dur_buf, sizeof(dur_buf), "%d:%02d:%02d", th, tm, tsec % 60);
-            else snprintf(dur_buf, sizeof(dur_buf), "%d:%02d", tm, tsec % 60);
+            if (th > 0) snprintf(dur_buf, sizeof(dur_buf), "%s%d:%02d:%02d", pfx, th, tm, tsec % 60);
+            else snprintf(dur_buf, sizeof(dur_buf), "%s%d:%02d", pfx, tm, tsec % 60);
             render_text_right(r, RENDER_FB_W - 18, y, dur_buf,
                              FONT_SCALE_1, COL_GRAY_LT);
         }

--- a/audiobook_app/ui.c
+++ b/audiobook_app/ui.c
@@ -76,6 +76,7 @@ typedef enum {
     HOME_FOLDERS,
     HOME_FINISHED,
     HOME_REFRESH,
+    HOME_SETTINGS,
     HOME_BACK,
     HOME_ITEM_COUNT
 } home_item_t;
@@ -88,6 +89,7 @@ static const char *home_labels[HOME_ITEM_COUNT] = {
     "Folders",
     "Finished",
     "Refresh Library",
+    "Settings",
     "Back to Menu",
 };
 
@@ -98,6 +100,7 @@ static void draw_list(ui_state_t *ui);
 static void draw_detail(ui_state_t *ui);
 static void draw_now_playing(ui_state_t *ui);
 static void draw_bookmarks(ui_state_t *ui);
+static void draw_settings(ui_state_t *ui);
 static void draw_chapters(ui_state_t *ui);
 static void draw_volume_overlay(ui_state_t *ui);
 
@@ -183,6 +186,7 @@ static int handle_list_touch(ui_state_t *ui, int x, int y);
 static int handle_detail_touch(ui_state_t *ui, int x, int y);
 static int handle_now_playing_touch(ui_state_t *ui, int x, int y);
 static int handle_bookmarks_touch(ui_state_t *ui, int x, int y);
+static int handle_settings_touch(ui_state_t *ui, int x, int y);
 static int handle_chapters_touch(ui_state_t *ui, int x, int y);
 static int handle_bookmarks_longpress(ui_state_t *ui, int x, int y);
 
@@ -863,6 +867,7 @@ void ui_draw_frame(uint16_t *buf) {
     render_clear(&g_ui.rend);
     switch (g_ui.screen) {
         case SCREEN_HOME:       draw_home(&g_ui); break;
+        case SCREEN_SETTINGS:   draw_settings(&g_ui); break;
         case SCREEN_LIST:       draw_list(&g_ui); break;
         case SCREEN_DETAIL:     draw_detail(&g_ui); break;
         case SCREEN_NOW_PLAYING: draw_now_playing(&g_ui); break;
@@ -891,6 +896,10 @@ int ui_run(uint16_t *fb, int fb_fd) {
         return -1;
     }
     ui_log("[ui] DB opened, starting event loop\n");
+
+    /* Load user settings before the first frame so the opening screen already
+     * reflects them rather than flipping a frame later. */
+    ui_settings_load(ui, ui->db);
 
     /* Build the initial screen's render cache (HOME) before enabling the draw
      * hook, so the first frame the render thread draws has valid data. */
@@ -1003,7 +1012,13 @@ int ui_run(uint16_t *fb, int fb_fd) {
             if (ui->input_fd >= 0 && FD_ISSET(ui->input_fd, &rfds)) {
                 struct input_event ev;
                 while (read(ui->input_fd, &ev, sizeof(ev)) == sizeof(ev)) {
-                    if (ui->blanked) {
+                    if (ui->blanked
+                        && ui->settings_val[SETTING_LOCK_DISABLE_TOUCH]) {
+                        /* "Lock disables touch": read and discard so nothing
+                         * queues up against our grab and replays on wake, but
+                         * act on none of it. Power key is then the only way
+                         * back. */
+                    } else if (ui->blanked) {
                         /* While blanked, don't navigate on taps; watch for a
                          * double-tap (two finger-ups within 350ms) to wake. */
                         int is_up = 0;
@@ -1289,6 +1304,7 @@ static void navigate_back(ui_state_t *ui) {
 int ui_handle_tap(ui_state_t *ui, int x, int y) {
     switch (ui->screen) {
         case SCREEN_HOME:       return handle_home_touch(ui, x, y);
+        case SCREEN_SETTINGS:   return handle_settings_touch(ui, x, y);
         case SCREEN_LIST:       return handle_list_touch(ui, x, y);
         case SCREEN_DETAIL:     return handle_detail_touch(ui, x, y);
         case SCREEN_NOW_PLAYING: return handle_now_playing_touch(ui, x, y);
@@ -1466,10 +1482,108 @@ static int handle_home_touch(ui_state_t *ui, int x, int y) {
             }
             break;
         }
+        case HOME_SETTINGS:
+            ui->settings_selected = 0;
+            navigate_to(ui, SCREEN_SETTINGS, ui->list_mode, 0);
+            break;
         case HOME_BACK:
             if (!ui->refresh_scanning) ui->running = 0;
             break;
     }
+    return 1;
+}
+
+
+/* ---- Screen drawing: Settings ------------------------------------------
+ *
+ * Three toggles, persisted in the same SQLite settings table playback_speed
+ * already uses. Each defaults to 0, i.e. exactly how the app behaved before
+ * the setting existed, so an upgrade changes nothing until it is asked to.
+ *
+ * The values are cached in ui_state_t because the render thread must not do
+ * database I/O; the DB is touched only when a row is tapped. */
+
+static const char *const settings_keys[SETTING_COUNT] = {
+    "lock_disable_touch",
+    "player_progress_bars",
+    "speed_adjusts_time",
+};
+
+static const char *const settings_labels[SETTING_COUNT] = {
+    "Lock disables touch",
+    "Chapter & book progress",
+    "Times follow speed",
+};
+
+/* Second line under each label: these settings are not self-explanatory from
+ * three words, and the screen is the only place they are documented. */
+static const char *const settings_help[SETTING_COUNT] = {
+    "No double-tap wake; power key only",
+    "Show both bars in Now Playing",
+    "Scale elapsed and remaining",
+};
+
+void ui_settings_load(ui_state_t *ui, sqlite3 *db) {
+    for (int i = 0; i < SETTING_COUNT; i++) {
+        char buf[16];
+        ui->settings_val[i] = 0;
+        if (db && audiobook_get_setting(db, settings_keys[i], buf, sizeof(buf)) == 0)
+            ui->settings_val[i] = (atoi(buf) != 0);
+    }
+}
+
+static void settings_toggle(ui_state_t *ui, int idx) {
+    if (idx < 0 || idx >= SETTING_COUNT) return;
+    ui->settings_val[idx] = !ui->settings_val[idx];
+    if (ui->db) {
+        char buf[4];
+        snprintf(buf, sizeof(buf), "%d", ui->settings_val[idx]);
+        audiobook_set_setting(ui->db, settings_keys[idx], buf);
+    }
+    ui_log("[ui] setting %s = %d\n", settings_keys[idx], ui->settings_val[idx]);
+}
+
+#define SETTINGS_ITEM_H 82
+
+static void draw_settings(ui_state_t *ui) {
+    renderer_t *r = &ui->rend;
+
+    render_text(r, 18, 16, "Settings", FONT_SCALE_2, COL_WHITE);
+    render_draw_hline(r, 0, TITLE_BAR_H - 1, RENDER_FB_W, COL_DIVIDER);
+
+    int y = TITLE_BAR_H;
+    for (int i = 0; i < SETTING_COUNT; i++) {
+        if (i == ui->settings_selected)
+            render_fill_rect(r, 0, y, 4, SETTINGS_ITEM_H, COL_ACCENT);
+
+        render_text(r, 24, y + 16, settings_labels[i], FONT_SCALE_2, COL_WHITE);
+        render_text(r, 24, y + 48, settings_help[i], FONT_SCALE_1, COL_GRAY_LT);
+
+        /* A filled pill reads as on/off at a glance on a 480px panel, where a
+         * tick box would be a few pixels of detail. */
+        int on = ui->settings_val[i];
+        int pw = 56, ph = 28;
+        int px = RENDER_FB_W - 24 - pw, py = y + 22;
+        render_fill_rect(r, px, py, pw, ph, on ? COL_ACCENT : COL_GRAY_DK);
+        render_fill_rect(r, on ? px + pw - ph : px, py, ph, ph, COL_WHITE);
+
+        y += SETTINGS_ITEM_H;
+        render_draw_hline(r, 0, y, RENDER_FB_W, COL_DIVIDER);
+    }
+
+    render_text(r, 24, RENDER_FB_H - 40, "Back", FONT_SCALE_2, COL_GRAY_LT);
+}
+
+static int handle_settings_touch(ui_state_t *ui, int x, int y) {
+    (void)x;
+    if (y < TITLE_BAR_H) { navigate_back(ui); return 1; }
+
+    if (y >= RENDER_FB_H - 56) { navigate_back(ui); return 1; }
+
+    int idx = (y - TITLE_BAR_H) / SETTINGS_ITEM_H;
+    if (idx < 0 || idx >= SETTING_COUNT) return 0;
+    ui->settings_selected = idx;
+    settings_toggle(ui, idx);
     return 1;
 }
 
@@ -1895,6 +2009,9 @@ static void rebuild_screen(ui_state_t *ui) {
         case SCREEN_NOW_PLAYING: rebuild_current_book(ui, 1); break;
         case SCREEN_BOOKMARKS:   rebuild_bookmarks(ui); break;
         case SCREEN_CHAPTERS:    rebuild_chapters(ui); break;
+        /* Settings draws from ui->settings_val, which is loaded once at startup
+         * and updated in place on tap, so there is no cache to rebuild. */
+        case SCREEN_SETTINGS:    break;
     }
 }
 

--- a/audiobook_app/ui.c
+++ b/audiobook_app/ui.c
@@ -211,6 +211,7 @@ static void rebuild_home(ui_state_t *ui);
 static void rebuild_list(ui_state_t *ui);
 static void rebuild_current_book(ui_state_t *ui, int with_cover);
 static void rebuild_cur_prog(ui_state_t *ui);
+static void refresh_chapter_cache(ui_state_t *ui);
 static void rebuild_bookmarks(ui_state_t *ui);
 static void rebuild_chapters(ui_state_t *ui);
 static void rebuild_screen(ui_state_t *ui);
@@ -1183,6 +1184,15 @@ int ui_run(uint16_t *fb, int fb_fd) {
             g_progress_dirty = 0;
             rebuild_cur_prog(ui);
             rebuild_home(ui);
+        } else if (ui->screen == SCREEN_NOW_PLAYING &&
+                   ui->settings_val[SETTING_PROGRESS_BARS]) {
+            /* The chapter bar needs bounds for the chapter being played, and
+             * rebuild_cur_prog only runs when the player saves progress — up to
+             * a minute apart, and never at all in the moments after entering
+             * this screen, when the snapshot is still empty. Refresh here
+             * instead; the staleness test inside means the DB is only queried
+             * when playback actually crosses into a different chapter. */
+            refresh_chapter_cache(ui);
         }
 
         int scan_rc = -1;
@@ -1954,14 +1964,124 @@ static void rebuild_current_book(ui_state_t *ui, int with_cover) {
 
 /* Progress-only refresh of the current-book cache (used on g_progress_dirty
  * ticks — the cover and book metadata don't change, so skip the decode). */
+/* Collector for the current track's duration: the snapshot carries a track_id
+ * and a position within the track, but not the track's length, and the chapter
+ * bar needs all three. */
+typedef struct { int want_id; int64_t dur_ms; } track_dur_ctx_t;
+
+static int track_dur_cb(const audiobook_track_t *t, void *ctx) {
+    track_dur_ctx_t *c = ctx;
+    if (t->track_id == c->want_id) c->dur_ms = t->duration_ms;
+    return 0;
+}
+
+/* Find the chapter containing a position within a track. */
+typedef struct {
+    int     want_track;
+    int64_t pos_ms;
+    int64_t start_ms, end_ms;
+    int     found;
+} chap_at_ctx_t;
+
+static int chap_at_cb(const audiobook_chapter_t *ch, void *ctx) {
+    chap_at_ctx_t *c = ctx;
+    if (c->found) return 0;
+    if (ch->track_id != c->want_track) return 0;
+    if (c->pos_ms >= ch->start_ms && (ch->end_ms <= 0 || c->pos_ms < ch->end_ms)) {
+        c->start_ms = ch->start_ms;
+        c->end_ms = ch->end_ms;
+        c->found = 1;
+    }
+    return 0;
+}
+
+
+/* Keep ui->cur_chap_* pointing at the chapter now playing.
+ *
+ * Split out of rebuild_cur_prog so the event loop can call it every tick while
+ * Now Playing is on screen: that function also re-reads progress from the DB
+ * and is far too heavy to run per tick, but the chapter bounds are needed
+ * promptly or the bar sits empty. The staleness test does the real work — the
+ * chapters query only runs when playback has actually left the cached range. */
+static void refresh_chapter_cache(ui_state_t *ui) {
+    if (ui->current_book_id <= 0) return;
+
+    player_snapshot_t snap;
+    player_get_snapshot(&snap);
+    if (snap.track_id <= 0 || snap.book_id != ui->current_book_id) return;
+
+    int64_t tpos = snap.track_position_ms;
+    if (ui->cur_chap_track_id == snap.track_id &&
+        ui->cur_chap_end_ms > ui->cur_chap_start_ms &&
+        tpos >= ui->cur_chap_start_ms && tpos < ui->cur_chap_end_ms)
+        return;   /* still inside the cached chapter */
+
+    chap_at_ctx_t c;
+    memset(&c, 0, sizeof(c));
+    c.want_track = snap.track_id;
+    c.pos_ms = tpos;
+    audiobook_get_chapters(ui->db, ui->current_book_id, chap_at_cb, &c);
+    if (!c.found) return;
+
+    int64_t end = c.end_ms > c.start_ms ? c.end_ms
+                  : ((ui->cur_track_dur_id == snap.track_id) ? ui->cur_track_dur_ms : 0);
+
+    pthread_mutex_lock(&g_cache_lock);
+    ui->cur_chap_track_id = snap.track_id;
+    ui->cur_chap_start_ms = c.start_ms;
+    ui->cur_chap_end_ms = end;
+    pthread_mutex_unlock(&g_cache_lock);
+}
+
 static void rebuild_cur_prog(ui_state_t *ui) {
     audiobook_progress_t p;
     int pok = 0;
     memset(&p, 0, sizeof(p));
     if (ui->current_book_id > 0)
         pok = (audiobook_get_progress(ui->db, ui->current_book_id, &p) > 0);
+
+    /* Refresh the cached track length only when the engine has moved to a
+     * different track — this walks the book's tracks, so it is not something to
+     * do on every rebuild, let alone every frame. */
+    player_snapshot_t snap;
+    player_get_snapshot(&snap);
+    int64_t tdur = ui->cur_track_dur_ms;
+    int tid = ui->cur_track_dur_id;
+    if (snap.track_id > 0 && snap.track_id != tid && ui->current_book_id > 0) {
+        track_dur_ctx_t c = { snap.track_id, 0 };
+        audiobook_get_tracks(ui->db, ui->current_book_id, track_dur_cb, &c);
+        tid = snap.track_id;
+        tdur = c.dur_ms;
+    }
+
+    /* Chapter bounds, re-queried only when playback leaves the cached chapter —
+     * otherwise this would walk every chapter of the book on each progress
+     * save, which happens every few seconds. */
+    int     ctid  = ui->cur_chap_track_id;
+    int64_t cstart = ui->cur_chap_start_ms, cend = ui->cur_chap_end_ms;
+    int64_t tpos  = snap.track_position_ms;
+    int stale = (ctid != snap.track_id) || (cend <= cstart) ||
+                (tpos < cstart) || (tpos >= cend);
+    if (snap.track_id > 0 && ui->current_book_id > 0 && stale) {
+        chap_at_ctx_t c;
+        memset(&c, 0, sizeof(c));
+        c.want_track = snap.track_id;
+        c.pos_ms = tpos;
+        audiobook_get_chapters(ui->db, ui->current_book_id, chap_at_cb, &c);
+        ctid = snap.track_id;
+        cstart = c.found ? c.start_ms : 0;
+        /* A final chapter often has no end; fall back to the track length so
+         * the bar still has a scale. */
+        cend = c.found ? (c.end_ms > c.start_ms ? c.end_ms : tdur) : 0;
+    }
+
     pthread_mutex_lock(&g_cache_lock);
     ui->cur_prog = p; ui->cur_prog_ok = pok;
+    ui->cur_track_dur_id = tid;
+    ui->cur_track_dur_ms = tdur;
+    ui->cur_chap_track_id = ctid;
+    ui->cur_chap_start_ms = cstart;
+    ui->cur_chap_end_ms = cend;
     pthread_mutex_unlock(&g_cache_lock);
 }
 
@@ -2020,7 +2140,13 @@ static void rebuild_screen(ui_state_t *ui) {
         case SCREEN_HOME:        rebuild_home(ui); break;
         case SCREEN_LIST:        rebuild_list(ui); break;
         case SCREEN_DETAIL:      rebuild_current_book(ui, 1); break;
-        case SCREEN_NOW_PLAYING: rebuild_current_book(ui, 1); break;
+        case SCREEN_NOW_PLAYING:
+            rebuild_current_book(ui, 1);
+            /* Also prime the progress/chapter cache. Without this the chapter
+             * bar stays blank on entry and only appears once the player
+             * happens to save progress, which can be tens of seconds. */
+            rebuild_cur_prog(ui);
+            break;
         case SCREEN_BOOKMARKS:   rebuild_bookmarks(ui); break;
         case SCREEN_CHAPTERS:    rebuild_chapters(ui); break;
         /* Settings draws from ui->settings_val, which is loaded once at startup
@@ -2558,17 +2684,69 @@ static void draw_now_playing(ui_state_t *ui) {
         total_ms = ui->scrub_total_ms;
     }
 
-    render_text(r, 16, y,
-                ui->settings_val[SETTING_SPEED_ADJUSTS_TIME] ? "Listened:"
-                                                             : "Position:",
-                FONT_SCALE_1, COL_GRAY_LT);
-    y += 30;
+    /* With the bars on, the "Chapter" and "Book" captions below already say
+     * what each figure is, and the two extra rows have to come from somewhere —
+     * so this header and part of the gap under the clock are given up rather
+     * than letting the screen overflow into the transport buttons. */
+    int bars_on = ui->settings_val[SETTING_PROGRESS_BARS] && engine_live;
+    if (!bars_on) {
+        render_text(r, 16, y,
+                    ui->settings_val[SETTING_SPEED_ADJUSTS_TIME] ? "Listened:"
+                                                                 : "Position:",
+                    FONT_SCALE_1, COL_GRAY_LT);
+        y += 30;
+    }
     render_time(r, 16, y, speed_scaled_ms(ui, pos_ms), FONT_SCALE_3, COL_WHITE);
-    y += 70;
+    y += bars_on ? 56 : 70;
 
     /* Progress bar with a draggable handle at the current position. Pressing
      * the handle (handle_now_playing_down) starts a scrub; the handle follows
      * the finger and the seek commits on release. */
+    /* Optional chapter bar, drawn above the book bar so the pair reads
+     * chapter-then-book, matching how a listener thinks about position. */
+    if (bars_on) {
+        /* No locking here: draw_now_playing already holds g_cache_lock for the
+         * whole draw, and it is a normal, non-recursive mutex — taking it again
+         * deadlocks the render thread against itself while the audio thread
+         * plays happily on, which is precisely how this first showed up. */
+        int64_t tpos = snap.track_position_ms;
+        int64_t tdur = (ui->cur_track_dur_id == snap.track_id)
+                       ? ui->cur_track_dur_ms : 0;
+
+        /* Prefer real chapter bounds: most audiobooks are one .m4b with
+         * embedded chapters, where track length is the whole book and would
+         * duplicate the bar below. Fall back to the track for multi-file books
+         * that carry no chapter marks, where a file is effectively a chapter. */
+        int64_t cstart = 0, clen = 0, cpos = 0;
+        if (ui->cur_chap_track_id == snap.track_id &&
+            ui->cur_chap_end_ms > ui->cur_chap_start_ms) {
+            cstart = ui->cur_chap_start_ms;
+            clen = ui->cur_chap_end_ms - cstart;
+            cpos = tpos - cstart;
+        } else if (tdur > 0 && tdur < total_ms) {
+            clen = tdur;
+            cpos = tpos;
+        }
+
+        if (clen > 0) {
+            int64_t tdur_unused = tdur; (void)tdur_unused;
+            tpos = cpos; tdur = clen;
+            double cfrac = (double)tpos / (double)tdur;
+            if (cfrac < 0) cfrac = 0;
+            if (cfrac > 1) cfrac = 1;
+            render_text(r, 16, y, "Chapter", FONT_SCALE_1, COL_GRAY_LT);
+            render_time(r, RENDER_FB_W - 96, y,
+                        speed_scaled_ms(ui, tdur - tpos), FONT_SCALE_1,
+                        COL_GRAY_LT);
+            y += 24;
+            render_progress_bar(r, 16, y, RENDER_FB_W - 32, 8, cfrac,
+                                COL_ORANGE, COL_GRAY_DK);
+            y += 22;
+            render_text(r, 16, y, "Book", FONT_SCALE_1, COL_GRAY_LT);
+            y += 24;
+        }
+    }
+
     if (total_ms > 0) {
         double frac = (double)pos_ms / (double)total_ms;
         if (frac < 0) frac = 0;

--- a/audiobook_app/ui.h
+++ b/audiobook_app/ui.h
@@ -27,7 +27,19 @@ typedef enum {
     SCREEN_NOW_PLAYING,
     SCREEN_BOOKMARKS,
     SCREEN_CHAPTERS,
+    SCREEN_SETTINGS,
 } ui_screen_t;
+
+/* ---- User settings ------------------------------------------------------
+ * Persisted in the same SQLite settings table as playback_speed, and cached
+ * here so the render thread never touches the database. Every one defaults to
+ * 0, which is the behaviour the app had before they existed. */
+typedef enum {
+    SETTING_LOCK_DISABLE_TOUCH = 0,  /* blanked screen ignores touch entirely */
+    SETTING_PROGRESS_BARS,           /* chapter + book bars in Now Playing */
+    SETTING_SPEED_ADJUSTS_TIME,      /* elapsed/remaining follow playback speed */
+    SETTING_COUNT
+} ui_setting_t;
 
 /* List view modes (what SCREEN_LIST shows) */
 typedef enum {
@@ -131,6 +143,8 @@ typedef struct {
 
     /* Home screen selection */
     int home_selected;
+    int settings_selected;
+    int settings_val[SETTING_COUNT];
 
     /* Current book for detail/now-playing */
     int current_book_id;
@@ -278,6 +292,10 @@ typedef struct {
  * The event loop reads touch but does NOT draw — the ioctl hook in hook.c
  * calls ui_draw_frame() on every hiby_player frame to render the UI. */
 int ui_run(uint16_t *fb, int fb_fd);
+
+/* Load the persisted user settings into ui->settings_val. Called once at
+ * startup; the screen updates the cache in place thereafter. */
+void ui_settings_load(ui_state_t *ui, sqlite3 *db);
 
 /* Draw the current screen to a specific framebuffer buffer.
  * Called from the ioctl hook (in hiby_player's render thread) on every

--- a/audiobook_app/ui.h
+++ b/audiobook_app/ui.h
@@ -146,6 +146,19 @@ typedef struct {
     int settings_selected;
     int settings_val[SETTING_COUNT];
 
+    /* Duration of the track the engine is on, cached by rebuild_cur_prog so
+     * draw_now_playing can size the chapter bar without touching the DB. */
+    int     cur_track_dur_id;    /* track_id the duration below belongs to */
+    int64_t cur_track_dur_ms;
+
+    /* Bounds of the chapter the engine is inside, in track time, cached by
+     * rebuild_cur_prog. Most audiobooks are a single .m4b with embedded
+     * chapters, so a chapter bar built only from track lengths would never
+     * appear for them. end <= start means "not known". */
+    int     cur_chap_track_id;
+    int64_t cur_chap_start_ms;
+    int64_t cur_chap_end_ms;
+
     /* Current book for detail/now-playing */
     int current_book_id;
 

--- a/tools/build_r1_audiobook_hook.sh
+++ b/tools/build_r1_audiobook_hook.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# POSIX equivalent of tools/build_r1_audiobook_hook.ps1, for building the hook
+# on macOS or Linux. Flags, sources and defines are kept deliberately identical
+# to the PowerShell script — if you change one, change both.
+#
+#   ./tools/build_r1_audiobook_hook.sh [output.so]
+#
+# Requires `zig` on PATH (brew install zig). The PowerShell script pins Zig
+# under .deps/zig on Windows; here we use whatever is installed, so check
+# `zig version` if a build starts behaving oddly.
+set -e
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+out=${1:-"$repo_root/build/libaudiobook_hook.so"}
+mkdir -p "$(dirname "$out")"
+
+command -v zig >/dev/null 2>&1 || {
+    echo "error: zig not found on PATH (brew install zig)" >&2
+    exit 1
+}
+
+# Zig ships the kernel headers the hook needs (linux/input.h and friends) under
+# its bundled libc tree; locate it rather than assuming a layout.
+zig_lib=$(zig env | sed -n 's/.*"lib_dir"[^"]*"\([^"]*\)".*/\1/p')
+[ -n "$zig_lib" ] || zig_lib=$(zig env | grep -o '/[^"]*lib' | head -1)
+kernel_include="$zig_lib/libc/include/any-linux-any"
+
+set -- \
+    audiobook_app/hook.c \
+    audiobook_app/ui.c \
+    audiobook_app/render.c \
+    audiobook_app/font.c \
+    audiobook_app/library.c \
+    audiobook_app/scan.c \
+    audiobook_app/tags.c \
+    audiobook_app/mp4_audio.c \
+    audiobook_app/cover.c \
+    audiobook_app/pngdec.c \
+    audiobook_app/bookmark_sd.c \
+    audiobook_app/storage_guard.c \
+    audiobook_app/player.c \
+    audiobook_app/wsola.c \
+    audiobook_app/sqlite3.c
+
+cd "$repo_root"
+
+# See the .ps1 for why each of these matters: glibc 2.22 hard-float to match
+# hiby_player, hidden visibility so our SQLite does not shadow the player's,
+# shared+PIC because this is LD_PRELOADed.
+zig cc \
+    -target mipsel-linux-gnueabihf.2.22 \
+    -shared -fPIC -fvisibility=hidden -fno-common -Os -s \
+    -I "$kernel_include" \
+    -I vendor \
+    -I vendor/libjpeg \
+    -DSQLITE_THREADSAFE=2 \
+    -DSQLITE_DEFAULT_MEMSTATUS=0 \
+    -DSQLITE_OMIT_LOAD_EXTENSION=1 \
+    -DSQLITE_ENABLE_FTS5=1 \
+    -DSQLITE_OMIT_DEPRECATED=1 \
+    -DSQLITE_TEMP_STORE=2 \
+    "$@" \
+    -lpthread -ldl -lm \
+    -o "$out"
+
+ls -la "$out"


### PR DESCRIPTION
Hi! I have been playing with your mod and really like the audiobook player. There were a couple of things I wanted to add for QoL for myself, so I asked Claude to come up with something. I'm afraid I don't know C, and can't verify the code myself. 

Please let me know if these kinds of PR aren't acceptable to you.

Also, it would be good to know what license you want to release your mod under :-)


TITLE: Add a Settings screen with lock, chapter progress-bar and speed-time options

---

Adds a Settings screen to the Audiobooks app, plus the three options it exists
to hold. Every one defaults to `0` — the behaviour the app already had — so
this changes nothing for existing users until a setting is turned on.

Values persist through the existing `audiobook_get_setting` /
`audiobook_set_setting` pair, in the same table `playback_speed` already uses,
and are cached in `ui_state_t` so the render thread never touches the database.

### The three settings

**Lock disables touch.** Blanking currently keeps the touch IC live so a
double-tap can wake the device, which means a player in a pocket is still
taking input. With this on, events are read and discarded while blanked, and
the power key becomes the only way back. They are *read* rather than ignored,
so nothing queues against the app's `EVIOCGRAB` and replays on wake.

**Chapter & book progress.** This draws a chapter bar above it with the time left in the chapter.
Bounds come from embedded chapter marks rather than track lengths, since nearly
every audiobook is a single `.m4b` whose one track is the entire book; a bar
built from track length would duplicate the book bar exactly. Multi-file books
without chapter marks fall back to track length. The bounds are refreshed from
the event loop, and the staleness check means the chapters query runs about once
per chapter rather than once per frame.

**Times follow speed.** Book positions are stored in book time, so at 1.5x the
player says an hour is left when it will take forty minutes to hear. With this
on the elapsed figure is divided by the current speed, the caption changes from
"Position" to "Listened", and the right-hand figure becomes time remaining
rather than total duration.

### Notes for review

- The two extra rows are paid for by dropping the caption and part of the gap
  under the clock when the bars are on; without that the screen overflows into
  the transport buttons.
- `tools/build_r1_audiobook_hook.sh` is added — a POSIX equivalent of the
  existing PowerShell build script, same sources, flags and defines, so the hook
  can be built on macOS and Linux. If one changes, the other needs the same
  change.
- Commits are stacked: the two feature commits both depend on the settings
  screen, so they are not independently mergeable as they stand. Happy to
  reshape into separate PRs if you would prefer that.

### Testing

Built with `zig cc` for `mipsel-linux-gnueabihf.2.22` and run on a real R1 on
2.0.26. Verified against a 15-chapter `.m4b`: chapter bounds resolve correctly,
the bar appears immediately on entering Now Playing, the chapter remaining
figure honours the speed setting, taps during a locked screen are discarded and
do not replay on wake, and the settings persist across reboots.
